### PR TITLE
Add function version to the AWSUniqueId dim

### DIFF
--- a/internal/metrics/metrics-emitter.go
+++ b/internal/metrics/metrics-emitter.go
@@ -99,7 +99,9 @@ func (emitter *MetricEmitter) Shutdown(condition shutdown.Condition) {
 }
 
 func (emitter MetricEmitter) buildAWSUniqueId(functionArn arn.ARN) string {
-	return fmt.Sprintf("lambda_%s_%s_%s", emitter.functionName, functionArn.Region, functionArn.AccountID)
+	return fmt.Sprintf("lambda_%s:%s_%s_%s",
+		emitter.functionName, emitter.functionVersion,
+		functionArn.Region, functionArn.AccountID)
 }
 
 func (emitter MetricEmitter) arnWithVersion(parsedArn arn.ARN) string {


### PR DESCRIPTION
This change is meant to fix an issue with property sync. It allows to distinguish function versions based on the AWSUniqueId dimension. This allows the tag syncer to correctly identify the function version and synchronize the properties assigned to the version.

As an outcome the extension will add the following to the AWSUniqueId dimension's value:
* `$LATEST` in case of using of the unpublished version
* a numeric value otherwise (aliases are translated to a numeric value - use the dimension `aws_function_qualifier` to verify that the call was made using an alias)

Examples:
* `lambda_jarekkawecki-signalfx-extension-demo-realm-time:$LATEST_eu-central-1_2222222222`
* `lambda_function:jarekkawecki-signalfx-extension-demo-realm-time:5_eu-central-1_2222222222`