### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ Go to the [docs directory](docs) for more details.
 The project is released under the terms of the Apache Software License version 2.0. For more details, see [the license file](./LICENSE).
 
 The project uses third-party components. For more details, see [the notice file](./NOTICE).
+
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.