### PR TITLE
introducing failFast for metrics sending

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -112,7 +112,7 @@ If you cannot see incoming data points, check [the troubleshooting instructions]
 ## Built-in dashboard
 
 You can build your own dashboard based on the metrics supported, but look first 
-at [built-in dashboards](https://docs.signalfx.com/en/latest/getting-started/built-in-content/built-in-dashboards.html#built-in-dashboards). 
+at [built-in dashboards](https://docs.splunk.com/Observability/data-visualization/dashboards/built-in-dashboards.html#built-in-dashboards). 
 A dashboard dedicated to the Splunk Lambda Extension is available under
 the `AWS Lambda` dashboard group. Its name is 'Lambda Extension'. The dashboard demonstrates what
 can be achieved with [the metrics the Extension Layer supports](#Metrics), and could be a good
@@ -175,7 +175,6 @@ Below is the full list of supported environment variables:
 |REPORTING_TIMEOUT|`5`|An integer (seconds). Minimum value is 1s.|Specifies metric send operation timeout.|
 |VERBOSE|`false`|`true` or `false`|Enables verbose logging. Logs are stored in a CloudWatch Logs group associated with a Lambda Function.|
 |HTTP_TRACING|`false`|`true` or `false`|Enables detailed logs on HTTP calls to Splunk.|
-
 
 ## Troubleshooting
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ const defaultReportingDuration = time.Duration(15) * time.Second
 const defaultReportingTimeout = time.Duration(5) * time.Second
 const defaultVerbose = false
 const defaultHttpTracing = false
+const defaultFailFast = false
 
 const ingestUrlFormat = "https://ingest.%s.signalfx.com"
 
@@ -45,6 +46,7 @@ const reportingDelayEnv = "REPORTING_RATE"
 const reportingTimeoutEnv = "REPORTING_TIMEOUT"
 const verboseEnv = "VERBOSE"
 const httpTracingEnv = "HTTP_TRACING"
+const failFastEnv = "SPLUNK_EXPERIMENTAL_FAIL_FAST"
 
 type Configuration struct {
 	SplunkRealm      string
@@ -55,6 +57,7 @@ type Configuration struct {
 	ReportingTimeout time.Duration
 	Verbose          bool
 	HttpTracing      bool
+	SplunkFailFast 	 bool
 }
 
 func New() Configuration {
@@ -67,6 +70,7 @@ func New() Configuration {
 		ReportingTimeout: durationOrDefault(reportingTimeoutEnv, defaultReportingTimeout),
 		Verbose:          boolOrDefault(verboseEnv, defaultVerbose),
 		HttpTracing:      boolOrDefault(httpTracingEnv, defaultHttpTracing),
+		SplunkFailFast:   boolOrDefault(failFastEnv, defaultFailFast),
 	}
 
 	if configuration.SplunkMetricsUrl == "" && configuration.SplunkRealm != "" {


### PR DESCRIPTION
Introducing an option to turn on/off fail fast for metrics sending.

FailFast true (the default behaviour)
If there is a problem with metrics sending, the extension will shutdown. This will cause AWS runtime to restart, failing the lambda in the process.

FailFast false 
In case of a problem with metrics sending, the extension will log a message but continue execution. Hence, lambdas will not be affected by lack of connectivity to o11y backend.