### PR TITLE
Add INSECURE_SKIP_HTTPS_VERIFY env var

### DIFF
--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -17,17 +17,18 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/splunk/lambda-extension/internal/config"
-	"github.com/splunk/lambda-extension/internal/extensionapi"
-	"github.com/splunk/lambda-extension/internal/metrics"
-	"github.com/splunk/lambda-extension/internal/ossignal"
-	"github.com/splunk/lambda-extension/internal/shutdown"
 	"io/ioutil"
 	"log"
 	"os"
 	"path"
 	"runtime"
 	"strings"
+
+	"github.com/splunk/lambda-extension/internal/config"
+	"github.com/splunk/lambda-extension/internal/extensionapi"
+	"github.com/splunk/lambda-extension/internal/metrics"
+	"github.com/splunk/lambda-extension/internal/ossignal"
+	"github.com/splunk/lambda-extension/internal/shutdown"
 )
 
 // the correct value is set by the go linker (it's done during build using "ldflags")
@@ -67,7 +68,7 @@ func registerApiAndStartMainLoop(m *metrics.MetricEmitter, configuration *config
 		}
 	}()
 
-	api, sc = extensionapi.Register(extensionName())
+	api, sc = extensionapi.Register(extensionName(), configuration)
 
 	if sc == nil {
 		sc = mainLoop(api, m, configuration)

--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -15,6 +15,11 @@
 package main
 
 import (
+	"github.com/splunk/lambda-extension/internal/config"
+	"github.com/splunk/lambda-extension/internal/extensionapi"
+	"github.com/splunk/lambda-extension/internal/metrics"
+	"github.com/splunk/lambda-extension/internal/ossignal"
+	"github.com/splunk/lambda-extension/internal/shutdown"
 	"bufio"
 	"fmt"
 	"io/ioutil"
@@ -23,11 +28,6 @@ import (
 	"path"
 	"runtime"
 	"strings"
-	"github.com/splunk/lambda-extension/internal/config"
-	"github.com/splunk/lambda-extension/internal/extensionapi"
-	"github.com/splunk/lambda-extension/internal/metrics"
-	"github.com/splunk/lambda-extension/internal/ossignal"
-	"github.com/splunk/lambda-extension/internal/shutdown"
 )
 
 // the correct value is set by the go linker (it's done during build using "ldflags")

--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -23,7 +23,6 @@ import (
 	"path"
 	"runtime"
 	"strings"
-
 	"github.com/splunk/lambda-extension/internal/config"
 	"github.com/splunk/lambda-extension/internal/extensionapi"
 	"github.com/splunk/lambda-extension/internal/metrics"

--- a/docs/README.md
+++ b/docs/README.md
@@ -175,7 +175,7 @@ Below is the full list of supported environment variables:
 |REPORTING_TIMEOUT|`5`|An integer (seconds). Minimum value is 1s.| Specifies metric send operation timeout.                                                                                                                                                                                                                                |
 |VERBOSE|`false`|`true` or `false`| Enables verbose logging. Logs are stored in a CloudWatch Logs group associated with a Lambda Function.                                                                                                                                                                  |
 |HTTP_TRACING|`false`|`true` or `false`| Enables detailed logs on HTTP calls to Splunk.                                                                                                                                                                                                                          |
-|INSECURE_SSL|`false`|`true` or `false`| Enables skip check validation ssl on HTTP calls to Splunk.                                                                                                                                                                                             |
+|INSECURE_HTTPS|`false`|`true` or `false`| Enables skip certificate validation for HTTPS calls to Splunk. Commonly used with the SPLUNK_INGEST_URL                                                                                                                                                                                            |
 
 ## Troubleshooting
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -175,7 +175,7 @@ Below is the full list of supported environment variables:
 |REPORTING_TIMEOUT|`5`|An integer (seconds). Minimum value is 1s.| Specifies metric send operation timeout.                                                                                                                                                                                                                                |
 |VERBOSE|`false`|`true` or `false`| Enables verbose logging. Logs are stored in a CloudWatch Logs group associated with a Lambda Function.                                                                                                                                                                  |
 |HTTP_TRACING|`false`|`true` or `false`| Enables detailed logs on HTTP calls to Splunk.                                                                                                                                                                                                                          |
-|INSECURE_HTTPS|`false`|`true` or `false`| Enables skip certificate validation for HTTPS calls to Splunk. Commonly used with the SPLUNK_INGEST_URL                                                                                                                                                                                            |
+|INSECURE_SKIP_HTTPS_VERIFY |`false`|`true` or `false`| Enables skip certificate validation for HTTPS calls to Splunk. Commonly used with the SPLUNK_INGEST_URL                                                                                                                                                                                            |
 
 ## Troubleshooting
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -165,16 +165,17 @@ send data points.
 
 Below is the full list of supported environment variables:
  
-|Name|Default value|Accepted values|Description|
-|---|---|---|---|
-|SPLUNK_REALM|`us0`| |The name of your organization's realm as described [here](https://dev.splunk.com/observability/docs/realms_in_endpoints/). It is used to build a standard endpoint for ingesting metrics.|
-|SPLUNK_INGEST_URL| |`https://ingest.eu0.signalfx.com`|Real-time Data Ingest - you can find it in your account settings screen. It overrides the endpoint defined by the `SPLUNK_REALM` variable and it can be used to point to non standard endpoints.|
-|SPLUNK_ACCESS_TOKEN| | |Access token as described [here](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#access-tokens).|
-|FAST_INGEST|`true`|`true` or `false`|Determines the strategy used to send data points. Use `true` to send metrics on every Lambda invocation ([fast ingest](#Fast-ingest) mode). With `false` metrics will be buffered and send out on intervals defined by `REPORTING_RATE` ([buffering](#Buffering) mode).|
-|REPORTING_RATE|`15`|An integer (seconds). Minimum value is 1s.|Specifies how often data points are sent to Splunk. Due to the way the AWS Lambda execution environment works, metrics may be sent less often.|  
-|REPORTING_TIMEOUT|`5`|An integer (seconds). Minimum value is 1s.|Specifies metric send operation timeout.|
-|VERBOSE|`false`|`true` or `false`|Enables verbose logging. Logs are stored in a CloudWatch Logs group associated with a Lambda Function.|
-|HTTP_TRACING|`false`|`true` or `false`|Enables detailed logs on HTTP calls to Splunk.|
+|Name|Default value|Accepted values| Description                                                                                                                                                                                                                                                             |
+|---|---|---|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|SPLUNK_REALM|`us0`| | The name of your organization's realm as described [here](https://dev.splunk.com/observability/docs/realms_in_endpoints/). It is used to build a standard endpoint for ingesting metrics.                                                                               |
+|SPLUNK_INGEST_URL| |`https://ingest.eu0.signalfx.com`| Real-time Data Ingest - you can find it in your account settings screen. It overrides the endpoint defined by the `SPLUNK_REALM` variable and it can be used to point to non standard endpoints.                                                                        |
+|SPLUNK_ACCESS_TOKEN| | | Access token as described [here](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#access-tokens).                                                                                                                                                            |
+|FAST_INGEST|`true`|`true` or `false`| Determines the strategy used to send data points. Use `true` to send metrics on every Lambda invocation ([fast ingest](#Fast-ingest) mode). With `false` metrics will be buffered and send out on intervals defined by `REPORTING_RATE` ([buffering](#Buffering) mode). |
+|REPORTING_RATE|`15`|An integer (seconds). Minimum value is 1s.| Specifies how often data points are sent to Splunk. Due to the way the AWS Lambda execution environment works, metrics may be sent less often.                                                                                                                          |  
+|REPORTING_TIMEOUT|`5`|An integer (seconds). Minimum value is 1s.| Specifies metric send operation timeout.                                                                                                                                                                                                                                |
+|VERBOSE|`false`|`true` or `false`| Enables verbose logging. Logs are stored in a CloudWatch Logs group associated with a Lambda Function.                                                                                                                                                                  |
+|HTTP_TRACING|`false`|`true` or `false`| Enables detailed logs on HTTP calls to Splunk.                                                                                                                                                                                                                          |
+|INSECURE_SSL|`false`|`true` or `false`| Enables skip check validation ssl on HTTP calls to Splunk.                                                                                                                                                                                             |
 
 ## Troubleshooting
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ const defaultReportingTimeout = time.Duration(5) * time.Second
 const defaultVerbose = false
 const defaultHttpTracing = false
 const defaultFailFast = false
+const defaultInsecureSsl = false
 
 const ingestUrlFormat = "https://ingest.%s.signalfx.com"
 
@@ -47,6 +48,7 @@ const reportingTimeoutEnv = "REPORTING_TIMEOUT"
 const verboseEnv = "VERBOSE"
 const httpTracingEnv = "HTTP_TRACING"
 const failFastEnv = "SPLUNK_EXPERIMENTAL_FAIL_FAST"
+const insecureSslEnv = "INSECURE_SSL"
 
 type Configuration struct {
 	SplunkRealm      string
@@ -57,7 +59,8 @@ type Configuration struct {
 	ReportingTimeout time.Duration
 	Verbose          bool
 	HttpTracing      bool
-	SplunkFailFast 	 bool
+	SplunkFailFast   bool
+	InsecureSsl      bool
 }
 
 func New() Configuration {
@@ -71,6 +74,7 @@ func New() Configuration {
 		Verbose:          boolOrDefault(verboseEnv, defaultVerbose),
 		HttpTracing:      boolOrDefault(httpTracingEnv, defaultHttpTracing),
 		SplunkFailFast:   boolOrDefault(failFastEnv, defaultFailFast),
+		InsecureSsl:      boolOrDefault(insecureSslEnv, defaultInsecureSsl),
 	}
 
 	if configuration.SplunkMetricsUrl == "" && configuration.SplunkRealm != "" {
@@ -102,6 +106,7 @@ func (c Configuration) String() string {
 	addLine("Reporting Timeout  = %v", c.ReportingTimeout.Seconds())
 	addLine("Verbose            = %v", c.Verbose)
 	addLine("HTTP Tracing       = %v", c.HttpTracing)
+	addLine("Insecure SSL 		= %v", c.InsecureSsl)
 
 	return builder.String()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,6 +107,7 @@ func (c Configuration) String() string {
 	addLine("Verbose            = %v", c.Verbose)
 	addLine("HTTP Tracing       = %v", c.HttpTracing)
 	addLine("InsecureHTTPS      = %v", c.HttpTracing)
+
 	return builder.String()
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,8 +106,7 @@ func (c Configuration) String() string {
 	addLine("Reporting Timeout  = %v", c.ReportingTimeout.Seconds())
 	addLine("Verbose            = %v", c.Verbose)
 	addLine("HTTP Tracing       = %v", c.HttpTracing)
-	addLine("InsecureHTTPS 		= %v", c.InsecureHTTPS)
-
+	addLine("InsecureHTTPS      = %v", c.HttpTracing)
 	return builder.String()
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,7 +106,7 @@ func (c Configuration) String() string {
 	addLine("Reporting Timeout  = %v", c.ReportingTimeout.Seconds())
 	addLine("Verbose            = %v", c.Verbose)
 	addLine("HTTP Tracing       = %v", c.HttpTracing)
-	addLine("InsecureHTTPS      = %v", c.HttpTracing)
+	addLine("InsecureHTTPS      = %v", c.InsecureHTTPS)
 
 	return builder.String()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,7 @@ const defaultReportingTimeout = time.Duration(5) * time.Second
 const defaultVerbose = false
 const defaultHttpTracing = false
 const defaultFailFast = false
-const defaultInsecureSsl = false
+const defaultInsecureHTTPS = false
 
 const ingestUrlFormat = "https://ingest.%s.signalfx.com"
 
@@ -48,7 +48,7 @@ const reportingTimeoutEnv = "REPORTING_TIMEOUT"
 const verboseEnv = "VERBOSE"
 const httpTracingEnv = "HTTP_TRACING"
 const failFastEnv = "SPLUNK_EXPERIMENTAL_FAIL_FAST"
-const insecureSslEnv = "INSECURE_SSL"
+const insecureHTTPSEnv = "INSECURE_HTTPS"
 
 type Configuration struct {
 	SplunkRealm      string
@@ -60,7 +60,7 @@ type Configuration struct {
 	Verbose          bool
 	HttpTracing      bool
 	SplunkFailFast   bool
-	InsecureSsl      bool
+	InsecureHTTPS    bool
 }
 
 func New() Configuration {
@@ -74,7 +74,7 @@ func New() Configuration {
 		Verbose:          boolOrDefault(verboseEnv, defaultVerbose),
 		HttpTracing:      boolOrDefault(httpTracingEnv, defaultHttpTracing),
 		SplunkFailFast:   boolOrDefault(failFastEnv, defaultFailFast),
-		InsecureSsl:      boolOrDefault(insecureSslEnv, defaultInsecureSsl),
+		InsecureHTTPS:      boolOrDefault(insecureHTTPSEnv, defaultInsecureHTTPS),
 	}
 
 	if configuration.SplunkMetricsUrl == "" && configuration.SplunkRealm != "" {
@@ -106,7 +106,7 @@ func (c Configuration) String() string {
 	addLine("Reporting Timeout  = %v", c.ReportingTimeout.Seconds())
 	addLine("Verbose            = %v", c.Verbose)
 	addLine("HTTP Tracing       = %v", c.HttpTracing)
-	addLine("Insecure SSL 		= %v", c.InsecureSsl)
+	addLine("InsecureHTTPS 		= %v", c.InsecureHTTPS)
 
 	return builder.String()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,7 @@ const defaultReportingTimeout = time.Duration(5) * time.Second
 const defaultVerbose = false
 const defaultHttpTracing = false
 const defaultFailFast = false
-const defaultInsecureHTTPS = false
+const defaultInsecureSkipHTTPSVerify = false
 
 const ingestUrlFormat = "https://ingest.%s.signalfx.com"
 
@@ -48,33 +48,33 @@ const reportingTimeoutEnv = "REPORTING_TIMEOUT"
 const verboseEnv = "VERBOSE"
 const httpTracingEnv = "HTTP_TRACING"
 const failFastEnv = "SPLUNK_EXPERIMENTAL_FAIL_FAST"
-const insecureHTTPSEnv = "INSECURE_HTTPS"
+const insecureSkipHTTPSVerifyEnv = "INSECURE_SKIP_HTTPS_VERIFY"
 
 type Configuration struct {
-	SplunkRealm      string
-	SplunkMetricsUrl string
-	SplunkToken      string
-	FastIngest       bool
-	ReportingDelay   time.Duration
-	ReportingTimeout time.Duration
-	Verbose          bool
-	HttpTracing      bool
-	SplunkFailFast   bool
-	InsecureHTTPS    bool
+	SplunkRealm             string
+	SplunkMetricsUrl        string
+	SplunkToken             string
+	FastIngest              bool
+	ReportingDelay          time.Duration
+	ReportingTimeout        time.Duration
+	Verbose                 bool
+	HttpTracing             bool
+	SplunkFailFast          bool
+	InsecureSkipHTTPSVerify bool
 }
 
 func New() Configuration {
 	configuration := Configuration{
-		SplunkRealm:      strOrDefault(realmEnv, defaultRealm),
-		SplunkMetricsUrl: strOrDefault(ingestURLEnv, strOrDefault(ingestURLEnvDeprecated, defaultIngestURL)),
-		SplunkToken:      strOrDefault(tokenEnv, defaultToken),
-		FastIngest:       boolOrDefault(fastIngestEnv, defaultFastIngest),
-		ReportingDelay:   durationOrDefault(reportingDelayEnv, defaultReportingDuration),
-		ReportingTimeout: durationOrDefault(reportingTimeoutEnv, defaultReportingTimeout),
-		Verbose:          boolOrDefault(verboseEnv, defaultVerbose),
-		HttpTracing:      boolOrDefault(httpTracingEnv, defaultHttpTracing),
-		SplunkFailFast:   boolOrDefault(failFastEnv, defaultFailFast),
-		InsecureHTTPS:    boolOrDefault(insecureHTTPSEnv, defaultInsecureHTTPS),
+		SplunkRealm:             strOrDefault(realmEnv, defaultRealm),
+		SplunkMetricsUrl:        strOrDefault(ingestURLEnv, strOrDefault(ingestURLEnvDeprecated, defaultIngestURL)),
+		SplunkToken:             strOrDefault(tokenEnv, defaultToken),
+		FastIngest:              boolOrDefault(fastIngestEnv, defaultFastIngest),
+		ReportingDelay:          durationOrDefault(reportingDelayEnv, defaultReportingDuration),
+		ReportingTimeout:        durationOrDefault(reportingTimeoutEnv, defaultReportingTimeout),
+		Verbose:                 boolOrDefault(verboseEnv, defaultVerbose),
+		HttpTracing:             boolOrDefault(httpTracingEnv, defaultHttpTracing),
+		SplunkFailFast:          boolOrDefault(failFastEnv, defaultFailFast),
+		InsecureSkipHTTPSVerify: boolOrDefault(insecureSkipHTTPSVerifyEnv, defaultInsecureSkipHTTPSVerify),
 	}
 
 	if configuration.SplunkMetricsUrl == "" && configuration.SplunkRealm != "" {
@@ -98,15 +98,15 @@ func (c Configuration) String() string {
 	builder := strings.Builder{}
 	addLine := func(format string, arg interface{}) { builder.WriteString(fmt.Sprintf(format+"\n", arg)) }
 
-	addLine("Splunk Realm       = %v", c.SplunkRealm)
-	addLine("Splunk Metrics URL = %v", c.SplunkMetricsUrl)
-	addLine("Splunk Token       = %v", obfuscatedToken(c.SplunkToken))
-	addLine("Fast Ingest        = %v", c.FastIngest)
-	addLine("Reporting Delay    = %v", c.ReportingDelay.Seconds())
-	addLine("Reporting Timeout  = %v", c.ReportingTimeout.Seconds())
-	addLine("Verbose            = %v", c.Verbose)
-	addLine("HTTP Tracing       = %v", c.HttpTracing)
-	addLine("InsecureHTTPS      = %v", c.InsecureHTTPS)
+	addLine("Splunk Realm           = %v", c.SplunkRealm)
+	addLine("Splunk Metrics URL     = %v", c.SplunkMetricsUrl)
+	addLine("Splunk Token           = %v", obfuscatedToken(c.SplunkToken))
+	addLine("Fast Ingest            = %v", c.FastIngest)
+	addLine("Reporting Delay        = %v", c.ReportingDelay.Seconds())
+	addLine("Reporting Timeout      = %v", c.ReportingTimeout.Seconds())
+	addLine("Verbose                = %v", c.Verbose)
+	addLine("HTTP Tracing           = %v", c.HttpTracing)
+	addLine("InsecureSkipHTTPSVerify= %v", c.InsecureSkipHTTPSVerify)
 
 	return builder.String()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,7 +74,7 @@ func New() Configuration {
 		Verbose:          boolOrDefault(verboseEnv, defaultVerbose),
 		HttpTracing:      boolOrDefault(httpTracingEnv, defaultHttpTracing),
 		SplunkFailFast:   boolOrDefault(failFastEnv, defaultFailFast),
-		InsecureHTTPS:      boolOrDefault(insecureHTTPSEnv, defaultInsecureHTTPS),
+		InsecureHTTPS:    boolOrDefault(insecureHTTPSEnv, defaultInsecureHTTPS),
 	}
 
 	if configuration.SplunkMetricsUrl == "" && configuration.SplunkRealm != "" {

--- a/internal/extensionapi/extensionapi.go
+++ b/internal/extensionapi/extensionapi.go
@@ -16,12 +16,15 @@ package extensionapi
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/splunk/lambda-extension/internal/shutdown"
 	"io/ioutil"
 	"log"
 	"net/http"
+
+	"github.com/splunk/lambda-extension/internal/config"
+	"github.com/splunk/lambda-extension/internal/shutdown"
 )
 
 const (
@@ -51,7 +54,7 @@ type RegisteredApi struct {
 	registerResponse
 }
 
-func Register(name string) (*RegisteredApi, shutdown.Condition) {
+func Register(name string, configuration *config.Configuration) (*RegisteredApi, shutdown.Condition) {
 	log.Println("Registering...")
 
 	rb, err := json.Marshal(map[string][]string{
@@ -61,6 +64,11 @@ func Register(name string) (*RegisteredApi, shutdown.Condition) {
 		return nil, shutdown.Api(fmt.Sprintf("can't marshall body: %v", err))
 	}
 
+	transportCfg := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: configuration.InsecureSsl},
+	}
+	client := &http.Client{Transport: transportCfg}
+
 	req, err := http.NewRequest(http.MethodPost, endpoints.register, bytes.NewBuffer(rb))
 
 	if err != nil {
@@ -69,7 +77,7 @@ func Register(name string) (*RegisteredApi, shutdown.Condition) {
 
 	req.Header.Set("Lambda-Extension-Name", name)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 
 	if err != nil {
 		return nil, shutdown.Api(fmt.Sprintf("can't register: %v", err))

--- a/internal/extensionapi/extensionapi.go
+++ b/internal/extensionapi/extensionapi.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-
 	"github.com/splunk/lambda-extension/internal/config"
 	"github.com/splunk/lambda-extension/internal/shutdown"
 )

--- a/internal/extensionapi/extensionapi.go
+++ b/internal/extensionapi/extensionapi.go
@@ -19,11 +19,11 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"github.com/splunk/lambda-extension/internal/config"
+	"github.com/splunk/lambda-extension/internal/shutdown"
 	"io/ioutil"
 	"log"
 	"net/http"
-	"github.com/splunk/lambda-extension/internal/config"
-	"github.com/splunk/lambda-extension/internal/shutdown"
 )
 
 const (
@@ -64,7 +64,7 @@ func Register(name string, configuration *config.Configuration) (*RegisteredApi,
 	}
 
 	transportCfg := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: configuration.InsecureHTTPS},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: configuration.InsecureSkipHTTPSVerify},
 	}
 	client := &http.Client{Transport: transportCfg}
 

--- a/internal/extensionapi/extensionapi.go
+++ b/internal/extensionapi/extensionapi.go
@@ -64,7 +64,7 @@ func Register(name string, configuration *config.Configuration) (*RegisteredApi,
 	}
 
 	transportCfg := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: configuration.InsecureSsl},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: configuration.InsecureHTTPS},
 	}
 	client := &http.Client{Transport: transportCfg}
 


### PR DESCRIPTION
1. Is it for the calls to Splunk Enterprise or Splunk Observability Cloud? 
  It's to Splunk Enterprise

2. Why would allow skipping the certificate validation? 
  I adopted the same solution used in the AWS ECS Log Driver for Splunk, which allow skipping the certificate. Docs: https://aws.amazon.com/pt/premiumsupport/knowledge-center/ecs-task-fargate-splunk-log-driver/ and https://www.splunk.com/en_us/blog/tips-and-tricks/splunk-logging-driver-for-docker.html

3. Why are you proposing this change? What is the scenario?
   Scenario consists of our App Lambda AWS sending the metrics to Splunk Enterprise, but when it try to send them using your layers solution, a certificate error occurs. We have internal solutions, but we would like to use official and clean solution from you. But we came across this SSL issue in the triggers.. 

4. Who are you? I work for a financial sector company in Brazil and i wish contribute with the community , for more details you can access my profile github/LinkedIn 



