### PR TITLE
feature: Add INSECURE_SKIP_HTTPS_VERIFY env var

### DIFF
--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -15,13 +15,13 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
 	"github.com/splunk/lambda-extension/internal/config"
 	"github.com/splunk/lambda-extension/internal/extensionapi"
 	"github.com/splunk/lambda-extension/internal/metrics"
 	"github.com/splunk/lambda-extension/internal/ossignal"
 	"github.com/splunk/lambda-extension/internal/shutdown"
+	"bufio"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -67,7 +67,7 @@ func registerApiAndStartMainLoop(m *metrics.MetricEmitter, configuration *config
 		}
 	}()
 
-	api, sc = extensionapi.Register(extensionName())
+	api, sc = extensionapi.Register(extensionName(), configuration)
 
 	if sc == nil {
 		sc = mainLoop(api, m, configuration)

--- a/docs/README.md
+++ b/docs/README.md
@@ -165,16 +165,17 @@ send data points.
 
 Below is the full list of supported environment variables:
  
-|Name|Default value|Accepted values|Description|
-|---|---|---|---|
-|SPLUNK_REALM|`us0`| |The name of your organization's realm as described [here](https://dev.splunk.com/observability/docs/realms_in_endpoints/). It is used to build a standard endpoint for ingesting metrics.|
-|SPLUNK_INGEST_URL| |`https://ingest.eu0.signalfx.com`|Real-time Data Ingest - you can find it in your account settings screen. It overrides the endpoint defined by the `SPLUNK_REALM` variable and it can be used to point to non standard endpoints.|
-|SPLUNK_ACCESS_TOKEN| | |Access token as described [here](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#access-tokens).|
-|FAST_INGEST|`true`|`true` or `false`|Determines the strategy used to send data points. Use `true` to send metrics on every Lambda invocation ([fast ingest](#Fast-ingest) mode). With `false` metrics will be buffered and send out on intervals defined by `REPORTING_RATE` ([buffering](#Buffering) mode).|
-|REPORTING_RATE|`15`|An integer (seconds). Minimum value is 1s.|Specifies how often data points are sent to Splunk. Due to the way the AWS Lambda execution environment works, metrics may be sent less often.|  
-|REPORTING_TIMEOUT|`5`|An integer (seconds). Minimum value is 1s.|Specifies metric send operation timeout.|
-|VERBOSE|`false`|`true` or `false`|Enables verbose logging. Logs are stored in a CloudWatch Logs group associated with a Lambda Function.|
-|HTTP_TRACING|`false`|`true` or `false`|Enables detailed logs on HTTP calls to Splunk.|
+|Name|Default value|Accepted values| Description                                                                                                                                                                                                                                                             |
+|---|---|---|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|SPLUNK_REALM|`us0`| | The name of your organization's realm as described [here](https://dev.splunk.com/observability/docs/realms_in_endpoints/). It is used to build a standard endpoint for ingesting metrics.                                                                               |
+|SPLUNK_INGEST_URL| |`https://ingest.eu0.signalfx.com`| Real-time Data Ingest - you can find it in your account settings screen. It overrides the endpoint defined by the `SPLUNK_REALM` variable and it can be used to point to non standard endpoints.                                                                        |
+|SPLUNK_ACCESS_TOKEN| | | Access token as described [here](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#access-tokens).                                                                                                                                                            |
+|FAST_INGEST|`true`|`true` or `false`| Determines the strategy used to send data points. Use `true` to send metrics on every Lambda invocation ([fast ingest](#Fast-ingest) mode). With `false` metrics will be buffered and send out on intervals defined by `REPORTING_RATE` ([buffering](#Buffering) mode). |
+|REPORTING_RATE|`15`|An integer (seconds). Minimum value is 1s.| Specifies how often data points are sent to Splunk. Due to the way the AWS Lambda execution environment works, metrics may be sent less often.                                                                                                                          |  
+|REPORTING_TIMEOUT|`5`|An integer (seconds). Minimum value is 1s.| Specifies metric send operation timeout.                                                                                                                                                                                                                                |
+|VERBOSE|`false`|`true` or `false`| Enables verbose logging. Logs are stored in a CloudWatch Logs group associated with a Lambda Function.                                                                                                                                                                  |
+|HTTP_TRACING|`false`|`true` or `false`| Enables detailed logs on HTTP calls to Splunk.                                                                                                                                                                                                                          |
+|INSECURE_SKIP_HTTPS_VERIFY |`false`|`true` or `false`| Enables skip certificate validation for HTTPS calls to Splunk. Commonly used with the SPLUNK_INGEST_URL                                                                                                                                                                                            |
 
 ## Troubleshooting
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ const defaultReportingTimeout = time.Duration(5) * time.Second
 const defaultVerbose = false
 const defaultHttpTracing = false
 const defaultFailFast = false
+const defaultInsecureSkipHTTPSVerify = false
 
 const ingestUrlFormat = "https://ingest.%s.signalfx.com"
 
@@ -47,30 +48,33 @@ const reportingTimeoutEnv = "REPORTING_TIMEOUT"
 const verboseEnv = "VERBOSE"
 const httpTracingEnv = "HTTP_TRACING"
 const failFastEnv = "SPLUNK_EXPERIMENTAL_FAIL_FAST"
+const insecureSkipHTTPSVerifyEnv = "INSECURE_SKIP_HTTPS_VERIFY"
 
 type Configuration struct {
-	SplunkRealm      string
-	SplunkMetricsUrl string
-	SplunkToken      string
-	FastIngest       bool
-	ReportingDelay   time.Duration
-	ReportingTimeout time.Duration
-	Verbose          bool
-	HttpTracing      bool
-	SplunkFailFast 	 bool
+	SplunkRealm             string
+	SplunkMetricsUrl        string
+	SplunkToken             string
+	FastIngest              bool
+	ReportingDelay          time.Duration
+	ReportingTimeout        time.Duration
+	Verbose                 bool
+	HttpTracing             bool
+	SplunkFailFast          bool
+	InsecureSkipHTTPSVerify bool
 }
 
 func New() Configuration {
 	configuration := Configuration{
-		SplunkRealm:      strOrDefault(realmEnv, defaultRealm),
-		SplunkMetricsUrl: strOrDefault(ingestURLEnv, strOrDefault(ingestURLEnvDeprecated, defaultIngestURL)),
-		SplunkToken:      strOrDefault(tokenEnv, defaultToken),
-		FastIngest:       boolOrDefault(fastIngestEnv, defaultFastIngest),
-		ReportingDelay:   durationOrDefault(reportingDelayEnv, defaultReportingDuration),
-		ReportingTimeout: durationOrDefault(reportingTimeoutEnv, defaultReportingTimeout),
-		Verbose:          boolOrDefault(verboseEnv, defaultVerbose),
-		HttpTracing:      boolOrDefault(httpTracingEnv, defaultHttpTracing),
-		SplunkFailFast:   boolOrDefault(failFastEnv, defaultFailFast),
+		SplunkRealm:             strOrDefault(realmEnv, defaultRealm),
+		SplunkMetricsUrl:        strOrDefault(ingestURLEnv, strOrDefault(ingestURLEnvDeprecated, defaultIngestURL)),
+		SplunkToken:             strOrDefault(tokenEnv, defaultToken),
+		FastIngest:              boolOrDefault(fastIngestEnv, defaultFastIngest),
+		ReportingDelay:          durationOrDefault(reportingDelayEnv, defaultReportingDuration),
+		ReportingTimeout:        durationOrDefault(reportingTimeoutEnv, defaultReportingTimeout),
+		Verbose:                 boolOrDefault(verboseEnv, defaultVerbose),
+		HttpTracing:             boolOrDefault(httpTracingEnv, defaultHttpTracing),
+		SplunkFailFast:          boolOrDefault(failFastEnv, defaultFailFast),
+		InsecureSkipHTTPSVerify: boolOrDefault(insecureSkipHTTPSVerifyEnv, defaultInsecureSkipHTTPSVerify),
 	}
 
 	if configuration.SplunkMetricsUrl == "" && configuration.SplunkRealm != "" {
@@ -94,14 +98,15 @@ func (c Configuration) String() string {
 	builder := strings.Builder{}
 	addLine := func(format string, arg interface{}) { builder.WriteString(fmt.Sprintf(format+"\n", arg)) }
 
-	addLine("Splunk Realm       = %v", c.SplunkRealm)
-	addLine("Splunk Metrics URL = %v", c.SplunkMetricsUrl)
-	addLine("Splunk Token       = %v", obfuscatedToken(c.SplunkToken))
-	addLine("Fast Ingest        = %v", c.FastIngest)
-	addLine("Reporting Delay    = %v", c.ReportingDelay.Seconds())
-	addLine("Reporting Timeout  = %v", c.ReportingTimeout.Seconds())
-	addLine("Verbose            = %v", c.Verbose)
-	addLine("HTTP Tracing       = %v", c.HttpTracing)
+	addLine("Splunk Realm           = %v", c.SplunkRealm)
+	addLine("Splunk Metrics URL     = %v", c.SplunkMetricsUrl)
+	addLine("Splunk Token           = %v", obfuscatedToken(c.SplunkToken))
+	addLine("Fast Ingest            = %v", c.FastIngest)
+	addLine("Reporting Delay        = %v", c.ReportingDelay.Seconds())
+	addLine("Reporting Timeout      = %v", c.ReportingTimeout.Seconds())
+	addLine("Verbose                = %v", c.Verbose)
+	addLine("HTTP Tracing           = %v", c.HttpTracing)
+	addLine("InsecureSkipHTTPSVerify= %v", c.InsecureSkipHTTPSVerify)
 
 	return builder.String()
 }


### PR DESCRIPTION
1. Is it for the calls to Splunk Enterprise or Splunk Observability Cloud? 
  It's to Splunk Enterprise

2. Why would allow skipping the certificate validation? 
  I adopted the same solution used in the AWS ECS Log Driver for Splunk, which allow skipping the certificate. Docs: https://aws.amazon.com/pt/premiumsupport/knowledge-center/ecs-task-fargate-splunk-log-driver/ and https://www.splunk.com/en_us/blog/tips-and-tricks/splunk-logging-driver-for-docker.html

3. Why are you proposing this change? What is the scenario?
   Scenario consists of our App Lambda AWS sending the metrics to Splunk Enterprise, but when it try to send them using your layers solution, a certificate error occurs. We have internal solutions, but we would like to use official and clean solution from you. But we came across this SSL issue in the triggers.. 

4. Who are you? I work for a financial sector company in Brazil and i wish contribute with the community , for more details you can access my profile github/LinkedIn 



