### PR TITLE
Disable config switch

### DIFF
--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -140,5 +140,6 @@ func extensionName() string {
 	if name == "" {
 		name = path.Base(os.Args[0])
 	}
+	fmt.Println("extension name is "+name)
 	return name
 }

--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -43,7 +43,7 @@ func enabled() (bool) {
 
 func main() {
 	enabled := enabled()
-	fmt.Println("starting extension enabled="+enabled)
+	fmt.Println("starting extension enabled? %t", enabled)
 
 	configuration := config.New()
 

--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -36,7 +36,7 @@ var gitVersion string
 const enabledKey = "SPLUNK_EXTENSION_WRAPPER_ENABLED"
 const extensionNameKey = "SPLUNK_EXTENSION_WRAPPER_NAME"
 
-func enabled() (bool) {
+func enabled() bool {
 	s := strings.ToLower(os.Getenv(enabledKey))
 	return s != "0" && s != "false"
 }

--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -97,7 +97,9 @@ func registerApiAndStartMainLoop(enabled bool, m *metrics.MetricEmitter, configu
 }
 
 func mainLoop(api *extensionapi.RegisteredApi, m *metrics.MetricEmitter, configuration *config.Configuration) (sc shutdown.Condition) {
-	m.SetFunction(api.FunctionName, api.FunctionVersion)
+	if m != nil {
+		m.SetFunction(api.FunctionName, api.FunctionVersion)
+	}
 
 	var event *extensionapi.Event
 	event, sc = api.NextEvent()

--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -43,7 +43,6 @@ func enabled() (bool) {
 
 func main() {
 	enabled := enabled()
-	fmt.Println("starting extension enabled? ", enabled)
 
 	configuration := config.New()
 

--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -43,6 +43,7 @@ func enabled() (bool) {
 
 func main() {
 	enabled := enabled()
+	fmt.Println("starting extension enabled="+enabled)
 
 	configuration := config.New()
 

--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -50,6 +50,9 @@ func main() {
 
 	ossignal.Watch()
 
+	// When we are running "disabled", don't actually try to emit metrics.
+	// A cleaner design for this would use an interface with a stub implementation,
+	// but 3 or 4 nil checks will do for now, since they're all in one file
 	var m *metrics.MetricEmitter = nil
 	if enabled {
 		m = metrics.New()

--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -36,6 +36,8 @@ var gitVersion string
 const enabledKey = "SPLUNK_EXTENSION_WRAPPER_ENABLED"
 const extensionNameKey = "SPLUNK_EXTENSION_WRAPPER_NAME"
 
+compilation failure
+
 func enabled() (bool) {
 	s := strings.ToLower(os.Getenv(enabledKey))
 	return s != "0" && s != "false"

--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -43,7 +43,7 @@ func enabled() (bool) {
 
 func main() {
 	enabled := enabled()
-	fmt.Println("starting extension enabled? %t", enabled)
+	fmt.Println("starting extension enabled? ", enabled)
 
 	configuration := config.New()
 
@@ -65,7 +65,9 @@ func main() {
 	log.Println("shutdown reason:", shutdownCondition.Reason())
 	log.Println("shutdown message:", shutdownCondition.Message())
 
-	m.Shutdown(shutdownCondition)
+	if m != nil {
+		m.Shutdown(shutdownCondition)
+	}
 }
 
 func registerApiAndStartMainLoop(enabled bool, m *metrics.MetricEmitter, configuration *config.Configuration) (sc shutdown.Condition) {
@@ -141,6 +143,5 @@ func extensionName() string {
 	if name == "" {
 		name = path.Base(os.Args[0])
 	}
-	fmt.Println("extension name is "+name)
 	return name
 }

--- a/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
+++ b/cmd/splunk-extension-wrapper/splunk-extension-wrapper.go
@@ -36,8 +36,6 @@ var gitVersion string
 const enabledKey = "SPLUNK_EXTENSION_WRAPPER_ENABLED"
 const extensionNameKey = "SPLUNK_EXTENSION_WRAPPER_NAME"
 
-compilation failure
-
 func enabled() (bool) {
 	s := strings.ToLower(os.Getenv(enabledKey))
 	return s != "0" && s != "false"

--- a/internal/extensionapi/extensionapi.go
+++ b/internal/extensionapi/extensionapi.go
@@ -54,7 +54,7 @@ type RegisteredApi struct {
 }
 
 func Register(enabled bool, name string, configuration *config.Configuration) (*RegisteredApi, shutdown.Condition) {
-	log.Println("Registering...")
+	log.Println("Registering... " + name)
 	events := []string{ shutdownType }
 	if enabled {
 		events = []string{ invokeType, shutdownType }

--- a/internal/extensionapi/extensionapi.go
+++ b/internal/extensionapi/extensionapi.go
@@ -53,11 +53,15 @@ type RegisteredApi struct {
 	registerResponse
 }
 
-func Register(name string, configuration *config.Configuration) (*RegisteredApi, shutdown.Condition) {
+func Register(enabled bool, name string, configuration *config.Configuration) (*RegisteredApi, shutdown.Condition) {
 	log.Println("Registering...")
+	events := []string{ shutdownType }
+	if enabled {
+		events = []string{ invokeType, shutdownType }
+	}
 
 	rb, err := json.Marshal(map[string][]string{
-		"events": {invokeType, shutdownType}})
+		"events": events})
 
 	if err != nil {
 		return nil, shutdown.Api(fmt.Sprintf("can't marshall body: %v", err))

--- a/internal/extensionapi/extensionapi.go
+++ b/internal/extensionapi/extensionapi.go
@@ -66,8 +66,6 @@ func Register(enabled bool, name string, configuration *config.Configuration) (*
 	if err != nil {
 		return nil, shutdown.Api(fmt.Sprintf("can't marshall body: %v", err))
 	}
-	log.Println("events "+string(rb))
-	fmt.Println("yes, here")
 
 	transportCfg := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: configuration.InsecureSkipHTTPSVerify},
@@ -100,7 +98,7 @@ func Register(enabled bool, name string, configuration *config.Configuration) (*
 
 	log.Printf("Register response: %v\n", body)
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		return nil, shutdown.Api("failed to register, API returned: " + resp.Status)
 	}
 

--- a/internal/extensionapi/extensionapi.go
+++ b/internal/extensionapi/extensionapi.go
@@ -55,6 +55,8 @@ type RegisteredApi struct {
 
 func Register(enabled bool, name string, configuration *config.Configuration) (*RegisteredApi, shutdown.Condition) {
 	log.Println("Registering... " + name)
+        // extensions have to at least call Register and Next; they can't actually be "disabled"
+	// so if we are not enabled, at least subscribe to SHUTDOWN
 	events := []string{ shutdownType }
 	if enabled {
 		events = []string{ invokeType, shutdownType }

--- a/internal/extensionapi/extensionapi.go
+++ b/internal/extensionapi/extensionapi.go
@@ -98,7 +98,7 @@ func Register(enabled bool, name string, configuration *config.Configuration) (*
 
 	log.Printf("Register response: %v\n", body)
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+	if resp.StatusCode != http.StatusOK {
 		return nil, shutdown.Api("failed to register, API returned: " + resp.Status)
 	}
 

--- a/internal/extensionapi/extensionapi.go
+++ b/internal/extensionapi/extensionapi.go
@@ -66,6 +66,8 @@ func Register(enabled bool, name string, configuration *config.Configuration) (*
 	if err != nil {
 		return nil, shutdown.Api(fmt.Sprintf("can't marshall body: %v", err))
 	}
+	log.Println("events "+string(rb))
+	fmt.Println("yes, here")
 
 	transportCfg := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: configuration.InsecureSkipHTTPSVerify},


### PR DESCRIPTION
Add a config environment variable to disable the collection of metrics through this extension.  Owing to the rules the lambda engine places on extensions, this isn't as simple as "just exit" - you still have to Register as an extension, and ask for at least the shutdown event.  Additionally, add a config switch for "extension name" to make a complicated workaround for disabling the opentelemetry collector possible.